### PR TITLE
Leverage support for Github Releases to download plugin binaries

### DIFF
--- a/provider/cmd/pulumi-resource-checkly/schema.json
+++ b/provider/cmd/pulumi-resource-checkly/schema.json
@@ -12,7 +12,7 @@
     "attribution": "This Pulumi package is based on the [`checkly` Terraform Provider](https://github.com/checkly/terraform-provider-checkly).",
     "repository": "https://github.com/checkly/pulumi-checkly",
     "logoUrl": "https://raw.githubusercontent.com/checkly/pulumi-checkly/main/assets/checkly.svg",
-    "pluginDownloadURL": "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+    "pluginDownloadURL": "github://api.github.com/checkly",
     "publisher": "checkly",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -57,7 +57,7 @@ func Provider() tfbridge.ProviderInfo {
 		Publisher:            "checkly",
 		LogoURL:              "https://raw.githubusercontent.com/checkly/pulumi-checkly/main/assets/checkly.svg",
 		Description:          "A Pulumi package for creating and managing Checkly monitoring resources.",
-		PluginDownloadURL:    "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+		PluginDownloadURL:    "github://api.github.com/checkly",
 		Keywords:             []string{"pulumi", "checkly", "category/monitoring"},
 		License:              "MIT",
 		Homepage:             "https://www.pulumi.com/registry/packages/checkly",

--- a/sdk/dotnet/AlertChannel.cs
+++ b/sdk/dotnet/AlertChannel.cs
@@ -184,7 +184,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Check.cs
+++ b/sdk/dotnet/Check.cs
@@ -202,7 +202,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/CheckGroup.cs
+++ b/sdk/dotnet/CheckGroup.cs
@@ -274,7 +274,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Dashboard.cs
+++ b/sdk/dotnet/Dashboard.cs
@@ -157,7 +157,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/EnvironmentVariable.cs
+++ b/sdk/dotnet/EnvironmentVariable.cs
@@ -72,7 +72,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/MaintenanceWindow.cs
+++ b/sdk/dotnet/MaintenanceWindow.cs
@@ -105,7 +105,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/PrivateLocation.cs
+++ b/sdk/dotnet/PrivateLocation.cs
@@ -81,7 +81,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Snippet.cs
+++ b/sdk/dotnet/Snippet.cs
@@ -47,7 +47,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/TriggerCheck.cs
+++ b/sdk/dotnet/TriggerCheck.cs
@@ -76,7 +76,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/TriggerCheckGroup.cs
+++ b/sdk/dotnet/TriggerCheckGroup.cs
@@ -76,7 +76,7 @@ namespace Pulumi.Checkly
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/checkly",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -58,7 +58,7 @@ namespace Pulumi.Checkly
         {
             InvokeOptions dst = src ?? new InvokeOptions{};
             dst.Version = src?.Version ?? Version;
-            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}";
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "github://api.github.com/checkly";
             return dst;
         }
 

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "checkly",
-  "server": "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"
+  "server": "github://api.github.com/checkly"
 }

--- a/sdk/go/checkly/alertChannel.go
+++ b/sdk/go/checkly/alertChannel.go
@@ -18,97 +18,100 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		emailAc, err := checkly.NewAlertChannel(ctx, "emailAc", &checkly.AlertChannelArgs{
-// 			Email: &AlertChannelEmailArgs{
-// 				Address: pulumi.String("john@example.com"),
-// 			},
-// 			SendRecovery:       pulumi.Bool(true),
-// 			SendFailure:        pulumi.Bool(false),
-// 			SendDegraded:       pulumi.Bool(true),
-// 			SslExpiry:          pulumi.Bool(true),
-// 			SslExpiryThreshold: pulumi.Int(22),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		smsAc, err := checkly.NewAlertChannel(ctx, "smsAc", &checkly.AlertChannelArgs{
-// 			Sms: &AlertChannelSmsArgs{
-// 				Name:   pulumi.String("john"),
-// 				Number: pulumi.String("+5491100001111"),
-// 			},
-// 			SendRecovery: pulumi.Bool(true),
-// 			SendFailure:  pulumi.Bool(true),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewAlertChannel(ctx, "slackAc", &checkly.AlertChannelArgs{
-// 			Slack: &AlertChannelSlackArgs{
-// 				Channel: pulumi.String("#checkly-notifications"),
-// 				Url:     pulumi.String("https://hooks.slack.com/services/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"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewAlertChannel(ctx, "opsgenieAc", &checkly.AlertChannelArgs{
-// 			Opsgenie: &AlertChannelOpsgenieArgs{
-// 				Name:     pulumi.String("opsalerts"),
-// 				ApiKey:   pulumi.String("fookey"),
-// 				Region:   pulumi.String("fooregion"),
-// 				Priority: pulumi.String("foopriority"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewAlertChannel(ctx, "pagerdutyAc", &checkly.AlertChannelArgs{
-// 			Pagerduty: &AlertChannelPagerdutyArgs{
-// 				Account:     pulumi.String("checkly"),
-// 				ServiceKey:  pulumi.String("key1"),
-// 				ServiceName: pulumi.String("pdalert"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewAlertChannel(ctx, "webhookAc", &checkly.AlertChannelArgs{
-// 			Webhook: &AlertChannelWebhookArgs{
-// 				Name:          pulumi.String("foo"),
-// 				Method:        pulumi.String("get"),
-// 				Template:      pulumi.String("footemplate"),
-// 				Url:           pulumi.String("https://example.com/foo"),
-// 				WebhookSecret: pulumi.String("foosecret"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewCheck(ctx, "exampleCheck", &checkly.CheckArgs{
-// 			AlertChannelSubscriptions: CheckAlertChannelSubscriptionArray{
-// 				&CheckAlertChannelSubscriptionArgs{
-// 					ChannelId: emailAc.ID(),
-// 					Activated: pulumi.Bool(true),
-// 				},
-// 				&CheckAlertChannelSubscriptionArgs{
-// 					ChannelId: smsAc.ID(),
-// 					Activated: pulumi.Bool(true),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			emailAc, err := checkly.NewAlertChannel(ctx, "emailAc", &checkly.AlertChannelArgs{
+//				Email: &AlertChannelEmailArgs{
+//					Address: pulumi.String("john@example.com"),
+//				},
+//				SendRecovery:       pulumi.Bool(true),
+//				SendFailure:        pulumi.Bool(false),
+//				SendDegraded:       pulumi.Bool(true),
+//				SslExpiry:          pulumi.Bool(true),
+//				SslExpiryThreshold: pulumi.Int(22),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			smsAc, err := checkly.NewAlertChannel(ctx, "smsAc", &checkly.AlertChannelArgs{
+//				Sms: &AlertChannelSmsArgs{
+//					Name:   pulumi.String("john"),
+//					Number: pulumi.String("+5491100001111"),
+//				},
+//				SendRecovery: pulumi.Bool(true),
+//				SendFailure:  pulumi.Bool(true),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewAlertChannel(ctx, "slackAc", &checkly.AlertChannelArgs{
+//				Slack: &AlertChannelSlackArgs{
+//					Channel: pulumi.String("#checkly-notifications"),
+//					Url:     pulumi.String("https://hooks.slack.com/services/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"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewAlertChannel(ctx, "opsgenieAc", &checkly.AlertChannelArgs{
+//				Opsgenie: &AlertChannelOpsgenieArgs{
+//					Name:     pulumi.String("opsalerts"),
+//					ApiKey:   pulumi.String("fookey"),
+//					Region:   pulumi.String("fooregion"),
+//					Priority: pulumi.String("foopriority"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewAlertChannel(ctx, "pagerdutyAc", &checkly.AlertChannelArgs{
+//				Pagerduty: &AlertChannelPagerdutyArgs{
+//					Account:     pulumi.String("checkly"),
+//					ServiceKey:  pulumi.String("key1"),
+//					ServiceName: pulumi.String("pdalert"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewAlertChannel(ctx, "webhookAc", &checkly.AlertChannelArgs{
+//				Webhook: &AlertChannelWebhookArgs{
+//					Name:          pulumi.String("foo"),
+//					Method:        pulumi.String("get"),
+//					Template:      pulumi.String("footemplate"),
+//					Url:           pulumi.String("https://example.com/foo"),
+//					WebhookSecret: pulumi.String("foosecret"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewCheck(ctx, "exampleCheck", &checkly.CheckArgs{
+//				AlertChannelSubscriptions: CheckAlertChannelSubscriptionArray{
+//					&CheckAlertChannelSubscriptionArgs{
+//						ChannelId: emailAc.ID(),
+//						Activated: pulumi.Bool(true),
+//					},
+//					&CheckAlertChannelSubscriptionArgs{
+//						ChannelId: smsAc.ID(),
+//						Activated: pulumi.Bool(true),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type AlertChannel struct {
 	pulumi.CustomResourceState
@@ -267,7 +270,7 @@ func (i *AlertChannel) ToAlertChannelOutputWithContext(ctx context.Context) Aler
 // AlertChannelArrayInput is an input type that accepts AlertChannelArray and AlertChannelArrayOutput values.
 // You can construct a concrete instance of `AlertChannelArrayInput` via:
 //
-//          AlertChannelArray{ AlertChannelArgs{...} }
+//	AlertChannelArray{ AlertChannelArgs{...} }
 type AlertChannelArrayInput interface {
 	pulumi.Input
 
@@ -292,7 +295,7 @@ func (i AlertChannelArray) ToAlertChannelArrayOutputWithContext(ctx context.Cont
 // AlertChannelMapInput is an input type that accepts AlertChannelMap and AlertChannelMapOutput values.
 // You can construct a concrete instance of `AlertChannelMapInput` via:
 //
-//          AlertChannelMap{ "key": AlertChannelArgs{...} }
+//	AlertChannelMap{ "key": AlertChannelArgs{...} }
 type AlertChannelMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/check.go
+++ b/sdk/go/checkly/check.go
@@ -418,7 +418,7 @@ func (i *Check) ToCheckOutputWithContext(ctx context.Context) CheckOutput {
 // CheckArrayInput is an input type that accepts CheckArray and CheckArrayOutput values.
 // You can construct a concrete instance of `CheckArrayInput` via:
 //
-//          CheckArray{ CheckArgs{...} }
+//	CheckArray{ CheckArgs{...} }
 type CheckArrayInput interface {
 	pulumi.Input
 
@@ -443,7 +443,7 @@ func (i CheckArray) ToCheckArrayOutputWithContext(ctx context.Context) CheckArra
 // CheckMapInput is an input type that accepts CheckMap and CheckMapOutput values.
 // You can construct a concrete instance of `CheckMapInput` via:
 //
-//          CheckMap{ "key": CheckArgs{...} }
+//	CheckMap{ "key": CheckArgs{...} }
 type CheckMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/checkGroup.go
+++ b/sdk/go/checkly/checkGroup.go
@@ -19,121 +19,124 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		testGroup1CheckGroup, err := checkly.NewCheckGroup(ctx, "testGroup1CheckGroup", &checkly.CheckGroupArgs{
-// 			Activated: pulumi.Bool(true),
-// 			Muted:     pulumi.Bool(false),
-// 			Tags: pulumi.StringArray{
-// 				pulumi.String("auto"),
-// 			},
-// 			Locations: pulumi.StringArray{
-// 				pulumi.String("eu-west-1"),
-// 			},
-// 			Concurrency: pulumi.Int(3),
-// 			ApiCheckDefaults: &CheckGroupApiCheckDefaultsArgs{
-// 				Url: pulumi.String("http://example.com/"),
-// 				Headers: pulumi.AnyMap{
-// 					"X-Test": pulumi.Any("foo"),
-// 				},
-// 				QueryParameters: pulumi.AnyMap{
-// 					"query": pulumi.Any("foo"),
-// 				},
-// 				Assertions: CheckGroupApiCheckDefaultsAssertionArray{
-// 					&CheckGroupApiCheckDefaultsAssertionArgs{
-// 						Source:     pulumi.String("STATUS_CODE"),
-// 						Property:   pulumi.String(""),
-// 						Comparison: pulumi.String("EQUALS"),
-// 						Target:     pulumi.String("200"),
-// 					},
-// 					&CheckGroupApiCheckDefaultsAssertionArgs{
-// 						Source:     pulumi.String("TEXT_BODY"),
-// 						Property:   pulumi.String(""),
-// 						Comparison: pulumi.String("CONTAINS"),
-// 						Target:     pulumi.String("welcome"),
-// 					},
-// 				},
-// 				BasicAuth: &CheckGroupApiCheckDefaultsBasicAuthArgs{
-// 					Username: pulumi.String("user"),
-// 					Password: pulumi.String("pass"),
-// 				},
-// 			},
-// 			EnvironmentVariables: pulumi.AnyMap{
-// 				"ENVTEST": pulumi.Any("Hello world"),
-// 			},
-// 			DoubleCheck:            pulumi.Bool(true),
-// 			UseGlobalAlertSettings: pulumi.Bool(false),
-// 			AlertSettings: &CheckGroupAlertSettingsArgs{
-// 				EscalationType: pulumi.String("RUN_BASED"),
-// 				RunBasedEscalations: CheckGroupAlertSettingsRunBasedEscalationArray{
-// 					&CheckGroupAlertSettingsRunBasedEscalationArgs{
-// 						FailedRunThreshold: pulumi.Int(1),
-// 					},
-// 				},
-// 				TimeBasedEscalations: CheckGroupAlertSettingsTimeBasedEscalationArray{
-// 					&CheckGroupAlertSettingsTimeBasedEscalationArgs{
-// 						MinutesFailingThreshold: pulumi.Int(5),
-// 					},
-// 				},
-// 				Reminders: CheckGroupAlertSettingsReminderArray{
-// 					&CheckGroupAlertSettingsReminderArgs{
-// 						Amount:   pulumi.Int(2),
-// 						Interval: pulumi.Int(5),
-// 					},
-// 				},
-// 			},
-// 			LocalSetupScript:    pulumi.String("setup-test"),
-// 			LocalTeardownScript: pulumi.String("teardown-test"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewCheck(ctx, "testCheck1", &checkly.CheckArgs{
-// 			GroupId:    testGroup1CheckGroup.ID(),
-// 			GroupOrder: pulumi.Int(1),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		emailAc1, err := checkly.NewAlertChannel(ctx, "emailAc1", &checkly.AlertChannelArgs{
-// 			Email: &AlertChannelEmailArgs{
-// 				Address: pulumi.String("info@example.com"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		emailAc2, err := checkly.NewAlertChannel(ctx, "emailAc2", &checkly.AlertChannelArgs{
-// 			Email: &AlertChannelEmailArgs{
-// 				Address: pulumi.String("info2@example.com"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewCheckGroup(ctx, "testGroup1Index/checkGroupCheckGroup", &checkly.CheckGroupArgs{
-// 			AlertChannelSubscriptions: CheckGroupAlertChannelSubscriptionArray{
-// 				&CheckGroupAlertChannelSubscriptionArgs{
-// 					ChannelId: emailAc1.ID(),
-// 					Activated: pulumi.Bool(true),
-// 				},
-// 				&CheckGroupAlertChannelSubscriptionArgs{
-// 					ChannelId: emailAc2.ID(),
-// 					Activated: pulumi.Bool(true),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			testGroup1CheckGroup, err := checkly.NewCheckGroup(ctx, "testGroup1CheckGroup", &checkly.CheckGroupArgs{
+//				Activated: pulumi.Bool(true),
+//				Muted:     pulumi.Bool(false),
+//				Tags: pulumi.StringArray{
+//					pulumi.String("auto"),
+//				},
+//				Locations: pulumi.StringArray{
+//					pulumi.String("eu-west-1"),
+//				},
+//				Concurrency: pulumi.Int(3),
+//				ApiCheckDefaults: &CheckGroupApiCheckDefaultsArgs{
+//					Url: pulumi.String("http://example.com/"),
+//					Headers: pulumi.AnyMap{
+//						"X-Test": pulumi.Any("foo"),
+//					},
+//					QueryParameters: pulumi.AnyMap{
+//						"query": pulumi.Any("foo"),
+//					},
+//					Assertions: CheckGroupApiCheckDefaultsAssertionArray{
+//						&CheckGroupApiCheckDefaultsAssertionArgs{
+//							Source:     pulumi.String("STATUS_CODE"),
+//							Property:   pulumi.String(""),
+//							Comparison: pulumi.String("EQUALS"),
+//							Target:     pulumi.String("200"),
+//						},
+//						&CheckGroupApiCheckDefaultsAssertionArgs{
+//							Source:     pulumi.String("TEXT_BODY"),
+//							Property:   pulumi.String(""),
+//							Comparison: pulumi.String("CONTAINS"),
+//							Target:     pulumi.String("welcome"),
+//						},
+//					},
+//					BasicAuth: &CheckGroupApiCheckDefaultsBasicAuthArgs{
+//						Username: pulumi.String("user"),
+//						Password: pulumi.String("pass"),
+//					},
+//				},
+//				EnvironmentVariables: pulumi.AnyMap{
+//					"ENVTEST": pulumi.Any("Hello world"),
+//				},
+//				DoubleCheck:            pulumi.Bool(true),
+//				UseGlobalAlertSettings: pulumi.Bool(false),
+//				AlertSettings: &CheckGroupAlertSettingsArgs{
+//					EscalationType: pulumi.String("RUN_BASED"),
+//					RunBasedEscalations: CheckGroupAlertSettingsRunBasedEscalationArray{
+//						&CheckGroupAlertSettingsRunBasedEscalationArgs{
+//							FailedRunThreshold: pulumi.Int(1),
+//						},
+//					},
+//					TimeBasedEscalations: CheckGroupAlertSettingsTimeBasedEscalationArray{
+//						&CheckGroupAlertSettingsTimeBasedEscalationArgs{
+//							MinutesFailingThreshold: pulumi.Int(5),
+//						},
+//					},
+//					Reminders: CheckGroupAlertSettingsReminderArray{
+//						&CheckGroupAlertSettingsReminderArgs{
+//							Amount:   pulumi.Int(2),
+//							Interval: pulumi.Int(5),
+//						},
+//					},
+//				},
+//				LocalSetupScript:    pulumi.String("setup-test"),
+//				LocalTeardownScript: pulumi.String("teardown-test"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewCheck(ctx, "testCheck1", &checkly.CheckArgs{
+//				GroupId:    testGroup1CheckGroup.ID(),
+//				GroupOrder: pulumi.Int(1),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			emailAc1, err := checkly.NewAlertChannel(ctx, "emailAc1", &checkly.AlertChannelArgs{
+//				Email: &AlertChannelEmailArgs{
+//					Address: pulumi.String("info@example.com"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			emailAc2, err := checkly.NewAlertChannel(ctx, "emailAc2", &checkly.AlertChannelArgs{
+//				Email: &AlertChannelEmailArgs{
+//					Address: pulumi.String("info2@example.com"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewCheckGroup(ctx, "testGroup1Index/checkGroupCheckGroup", &checkly.CheckGroupArgs{
+//				AlertChannelSubscriptions: CheckGroupAlertChannelSubscriptionArray{
+//					&CheckGroupAlertChannelSubscriptionArgs{
+//						ChannelId: emailAc1.ID(),
+//						Activated: pulumi.Bool(true),
+//					},
+//					&CheckGroupAlertChannelSubscriptionArgs{
+//						ChannelId: emailAc2.ID(),
+//						Activated: pulumi.Bool(true),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type CheckGroup struct {
 	pulumi.CustomResourceState
@@ -406,7 +409,7 @@ func (i *CheckGroup) ToCheckGroupOutputWithContext(ctx context.Context) CheckGro
 // CheckGroupArrayInput is an input type that accepts CheckGroupArray and CheckGroupArrayOutput values.
 // You can construct a concrete instance of `CheckGroupArrayInput` via:
 //
-//          CheckGroupArray{ CheckGroupArgs{...} }
+//	CheckGroupArray{ CheckGroupArgs{...} }
 type CheckGroupArrayInput interface {
 	pulumi.Input
 
@@ -431,7 +434,7 @@ func (i CheckGroupArray) ToCheckGroupArrayOutputWithContext(ctx context.Context)
 // CheckGroupMapInput is an input type that accepts CheckGroupMap and CheckGroupMapOutput values.
 // You can construct a concrete instance of `CheckGroupMapInput` via:
 //
-//          CheckGroupMap{ "key": CheckGroupArgs{...} }
+//	CheckGroupMap{ "key": CheckGroupArgs{...} }
 type CheckGroupMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/dashboard.go
+++ b/sdk/go/checkly/dashboard.go
@@ -17,32 +17,35 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := checkly.NewDashboard(ctx, "dashboard1", &checkly.DashboardArgs{
-// 			CustomDomain:   pulumi.String("status.example.com"),
-// 			CustomUrl:      pulumi.String("checkly"),
-// 			Header:         pulumi.String("Public dashboard"),
-// 			HideTags:       pulumi.Bool(false),
-// 			Logo:           pulumi.String("https://www.checklyhq.com/logo.png"),
-// 			Paginate:       pulumi.Bool(false),
-// 			PaginationRate: pulumi.Int(30),
-// 			RefreshRate:    pulumi.Int(60),
-// 			Tags: pulumi.StringArray{
-// 				pulumi.String("production"),
-// 			},
-// 			Width: pulumi.String("FULL"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := checkly.NewDashboard(ctx, "dashboard1", &checkly.DashboardArgs{
+//				CustomDomain:   pulumi.String("status.example.com"),
+//				CustomUrl:      pulumi.String("checkly"),
+//				Header:         pulumi.String("Public dashboard"),
+//				HideTags:       pulumi.Bool(false),
+//				Logo:           pulumi.String("https://www.checklyhq.com/logo.png"),
+//				Paginate:       pulumi.Bool(false),
+//				PaginationRate: pulumi.Int(30),
+//				RefreshRate:    pulumi.Int(60),
+//				Tags: pulumi.StringArray{
+//					pulumi.String("production"),
+//				},
+//				Width: pulumi.String("FULL"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type Dashboard struct {
 	pulumi.CustomResourceState
@@ -274,7 +277,7 @@ func (i *Dashboard) ToDashboardOutputWithContext(ctx context.Context) DashboardO
 // DashboardArrayInput is an input type that accepts DashboardArray and DashboardArrayOutput values.
 // You can construct a concrete instance of `DashboardArrayInput` via:
 //
-//          DashboardArray{ DashboardArgs{...} }
+//	DashboardArray{ DashboardArgs{...} }
 type DashboardArrayInput interface {
 	pulumi.Input
 
@@ -299,7 +302,7 @@ func (i DashboardArray) ToDashboardArrayOutputWithContext(ctx context.Context) D
 // DashboardMapInput is an input type that accepts DashboardMap and DashboardMapOutput values.
 // You can construct a concrete instance of `DashboardMapInput` via:
 //
-//          DashboardMap{ "key": DashboardArgs{...} }
+//	DashboardMap{ "key": DashboardArgs{...} }
 type DashboardMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/doc.go
+++ b/sdk/go/checkly/doc.go
@@ -1,3 +1,2 @@
 // A Pulumi package for creating and managing Checkly monitoring resources.
-//
 package checkly

--- a/sdk/go/checkly/environmentVariable.go
+++ b/sdk/go/checkly/environmentVariable.go
@@ -17,30 +17,33 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := checkly.NewEnvironmentVariable(ctx, "variable1", &checkly.EnvironmentVariableArgs{
-// 			Key:    pulumi.String("API_KEY"),
-// 			Locked: pulumi.Bool(true),
-// 			Value:  pulumi.String("loZd9hOGHDUrGvmW"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = checkly.NewEnvironmentVariable(ctx, "variable2", &checkly.EnvironmentVariableArgs{
-// 			Key:   pulumi.String("API_URL"),
-// 			Value: pulumi.String("http://localhost:3000"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := checkly.NewEnvironmentVariable(ctx, "variable1", &checkly.EnvironmentVariableArgs{
+//				Key:    pulumi.String("API_KEY"),
+//				Locked: pulumi.Bool(true),
+//				Value:  pulumi.String("loZd9hOGHDUrGvmW"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = checkly.NewEnvironmentVariable(ctx, "variable2", &checkly.EnvironmentVariableArgs{
+//				Key:   pulumi.String("API_URL"),
+//				Value: pulumi.String("http://localhost:3000"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type EnvironmentVariable struct {
 	pulumi.CustomResourceState
@@ -140,7 +143,7 @@ func (i *EnvironmentVariable) ToEnvironmentVariableOutputWithContext(ctx context
 // EnvironmentVariableArrayInput is an input type that accepts EnvironmentVariableArray and EnvironmentVariableArrayOutput values.
 // You can construct a concrete instance of `EnvironmentVariableArrayInput` via:
 //
-//          EnvironmentVariableArray{ EnvironmentVariableArgs{...} }
+//	EnvironmentVariableArray{ EnvironmentVariableArgs{...} }
 type EnvironmentVariableArrayInput interface {
 	pulumi.Input
 
@@ -165,7 +168,7 @@ func (i EnvironmentVariableArray) ToEnvironmentVariableArrayOutputWithContext(ct
 // EnvironmentVariableMapInput is an input type that accepts EnvironmentVariableMap and EnvironmentVariableMapOutput values.
 // You can construct a concrete instance of `EnvironmentVariableMapInput` via:
 //
-//          EnvironmentVariableMap{ "key": EnvironmentVariableArgs{...} }
+//	EnvironmentVariableMap{ "key": EnvironmentVariableArgs{...} }
 type EnvironmentVariableMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/maintenanceWindow.go
+++ b/sdk/go/checkly/maintenanceWindow.go
@@ -17,28 +17,31 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := checkly.NewMaintenanceWindow(ctx, "maintenance1", &checkly.MaintenanceWindowArgs{
-// 			EndsAt:         pulumi.String("2014-08-25T00:00:00.000Z"),
-// 			RepeatEndsAt:   pulumi.String("2014-08-24T00:00:00.000Z"),
-// 			RepeatInterval: pulumi.Int(1),
-// 			RepeatUnit:     pulumi.String("MONTH"),
-// 			StartsAt:       pulumi.String("2014-08-24T00:00:00.000Z"),
-// 			Tags: pulumi.StringArray{
-// 				pulumi.String("production"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := checkly.NewMaintenanceWindow(ctx, "maintenance1", &checkly.MaintenanceWindowArgs{
+//				EndsAt:         pulumi.String("2014-08-25T00:00:00.000Z"),
+//				RepeatEndsAt:   pulumi.String("2014-08-24T00:00:00.000Z"),
+//				RepeatInterval: pulumi.Int(1),
+//				RepeatUnit:     pulumi.String("MONTH"),
+//				StartsAt:       pulumi.String("2014-08-24T00:00:00.000Z"),
+//				Tags: pulumi.StringArray{
+//					pulumi.String("production"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type MaintenanceWindow struct {
 	pulumi.CustomResourceState
@@ -193,7 +196,7 @@ func (i *MaintenanceWindow) ToMaintenanceWindowOutputWithContext(ctx context.Con
 // MaintenanceWindowArrayInput is an input type that accepts MaintenanceWindowArray and MaintenanceWindowArrayOutput values.
 // You can construct a concrete instance of `MaintenanceWindowArrayInput` via:
 //
-//          MaintenanceWindowArray{ MaintenanceWindowArgs{...} }
+//	MaintenanceWindowArray{ MaintenanceWindowArgs{...} }
 type MaintenanceWindowArrayInput interface {
 	pulumi.Input
 
@@ -218,7 +221,7 @@ func (i MaintenanceWindowArray) ToMaintenanceWindowArrayOutputWithContext(ctx co
 // MaintenanceWindowMapInput is an input type that accepts MaintenanceWindowMap and MaintenanceWindowMapOutput values.
 // You can construct a concrete instance of `MaintenanceWindowMapInput` via:
 //
-//          MaintenanceWindowMap{ "key": MaintenanceWindowArgs{...} }
+//	MaintenanceWindowMap{ "key": MaintenanceWindowArgs{...} }
 type MaintenanceWindowMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/privateLocation.go
+++ b/sdk/go/checkly/privateLocation.go
@@ -17,22 +17,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := checkly.NewPrivateLocation(ctx, "location", &checkly.PrivateLocationArgs{
-// 			Icon:     pulumi.String("location"),
-// 			SlugName: pulumi.String("new-private-location"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := checkly.NewPrivateLocation(ctx, "location", &checkly.PrivateLocationArgs{
+//				Icon:     pulumi.String("location"),
+//				SlugName: pulumi.String("new-private-location"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 type PrivateLocation struct {
 	pulumi.CustomResourceState
@@ -150,7 +153,7 @@ func (i *PrivateLocation) ToPrivateLocationOutputWithContext(ctx context.Context
 // PrivateLocationArrayInput is an input type that accepts PrivateLocationArray and PrivateLocationArrayOutput values.
 // You can construct a concrete instance of `PrivateLocationArrayInput` via:
 //
-//          PrivateLocationArray{ PrivateLocationArgs{...} }
+//	PrivateLocationArray{ PrivateLocationArgs{...} }
 type PrivateLocationArrayInput interface {
 	pulumi.Input
 
@@ -175,7 +178,7 @@ func (i PrivateLocationArray) ToPrivateLocationArrayOutputWithContext(ctx contex
 // PrivateLocationMapInput is an input type that accepts PrivateLocationMap and PrivateLocationMapOutput values.
 // You can construct a concrete instance of `PrivateLocationMapInput` via:
 //
-//          PrivateLocationMap{ "key": PrivateLocationArgs{...} }
+//	PrivateLocationMap{ "key": PrivateLocationArgs{...} }
 type PrivateLocationMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/pulumi-plugin.json
+++ b/sdk/go/checkly/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "checkly",
-  "server": "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"
+  "server": "github://api.github.com/checkly"
 }

--- a/sdk/go/checkly/pulumiTypes.go
+++ b/sdk/go/checkly/pulumiTypes.go
@@ -17,7 +17,7 @@ type AlertChannelEmail struct {
 // AlertChannelEmailInput is an input type that accepts AlertChannelEmailArgs and AlertChannelEmailOutput values.
 // You can construct a concrete instance of `AlertChannelEmailInput` via:
 //
-//          AlertChannelEmailArgs{...}
+//	AlertChannelEmailArgs{...}
 type AlertChannelEmailInput interface {
 	pulumi.Input
 
@@ -52,11 +52,11 @@ func (i AlertChannelEmailArgs) ToAlertChannelEmailPtrOutputWithContext(ctx conte
 // AlertChannelEmailPtrInput is an input type that accepts AlertChannelEmailArgs, AlertChannelEmailPtr and AlertChannelEmailPtrOutput values.
 // You can construct a concrete instance of `AlertChannelEmailPtrInput` via:
 //
-//          AlertChannelEmailArgs{...}
+//	        AlertChannelEmailArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelEmailPtrInput interface {
 	pulumi.Input
 
@@ -153,7 +153,7 @@ type AlertChannelOpsgenie struct {
 // AlertChannelOpsgenieInput is an input type that accepts AlertChannelOpsgenieArgs and AlertChannelOpsgenieOutput values.
 // You can construct a concrete instance of `AlertChannelOpsgenieInput` via:
 //
-//          AlertChannelOpsgenieArgs{...}
+//	AlertChannelOpsgenieArgs{...}
 type AlertChannelOpsgenieInput interface {
 	pulumi.Input
 
@@ -191,11 +191,11 @@ func (i AlertChannelOpsgenieArgs) ToAlertChannelOpsgeniePtrOutputWithContext(ctx
 // AlertChannelOpsgeniePtrInput is an input type that accepts AlertChannelOpsgenieArgs, AlertChannelOpsgeniePtr and AlertChannelOpsgeniePtrOutput values.
 // You can construct a concrete instance of `AlertChannelOpsgeniePtrInput` via:
 //
-//          AlertChannelOpsgenieArgs{...}
+//	        AlertChannelOpsgenieArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelOpsgeniePtrInput interface {
 	pulumi.Input
 
@@ -330,7 +330,7 @@ type AlertChannelPagerduty struct {
 // AlertChannelPagerdutyInput is an input type that accepts AlertChannelPagerdutyArgs and AlertChannelPagerdutyOutput values.
 // You can construct a concrete instance of `AlertChannelPagerdutyInput` via:
 //
-//          AlertChannelPagerdutyArgs{...}
+//	AlertChannelPagerdutyArgs{...}
 type AlertChannelPagerdutyInput interface {
 	pulumi.Input
 
@@ -367,11 +367,11 @@ func (i AlertChannelPagerdutyArgs) ToAlertChannelPagerdutyPtrOutputWithContext(c
 // AlertChannelPagerdutyPtrInput is an input type that accepts AlertChannelPagerdutyArgs, AlertChannelPagerdutyPtr and AlertChannelPagerdutyPtrOutput values.
 // You can construct a concrete instance of `AlertChannelPagerdutyPtrInput` via:
 //
-//          AlertChannelPagerdutyArgs{...}
+//	        AlertChannelPagerdutyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelPagerdutyPtrInput interface {
 	pulumi.Input
 
@@ -492,7 +492,7 @@ type AlertChannelSlack struct {
 // AlertChannelSlackInput is an input type that accepts AlertChannelSlackArgs and AlertChannelSlackOutput values.
 // You can construct a concrete instance of `AlertChannelSlackInput` via:
 //
-//          AlertChannelSlackArgs{...}
+//	AlertChannelSlackArgs{...}
 type AlertChannelSlackInput interface {
 	pulumi.Input
 
@@ -528,11 +528,11 @@ func (i AlertChannelSlackArgs) ToAlertChannelSlackPtrOutputWithContext(ctx conte
 // AlertChannelSlackPtrInput is an input type that accepts AlertChannelSlackArgs, AlertChannelSlackPtr and AlertChannelSlackPtrOutput values.
 // You can construct a concrete instance of `AlertChannelSlackPtrInput` via:
 //
-//          AlertChannelSlackArgs{...}
+//	        AlertChannelSlackArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelSlackPtrInput interface {
 	pulumi.Input
 
@@ -640,7 +640,7 @@ type AlertChannelSms struct {
 // AlertChannelSmsInput is an input type that accepts AlertChannelSmsArgs and AlertChannelSmsOutput values.
 // You can construct a concrete instance of `AlertChannelSmsInput` via:
 //
-//          AlertChannelSmsArgs{...}
+//	AlertChannelSmsArgs{...}
 type AlertChannelSmsInput interface {
 	pulumi.Input
 
@@ -676,11 +676,11 @@ func (i AlertChannelSmsArgs) ToAlertChannelSmsPtrOutputWithContext(ctx context.C
 // AlertChannelSmsPtrInput is an input type that accepts AlertChannelSmsArgs, AlertChannelSmsPtr and AlertChannelSmsPtrOutput values.
 // You can construct a concrete instance of `AlertChannelSmsPtrInput` via:
 //
-//          AlertChannelSmsArgs{...}
+//	        AlertChannelSmsArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelSmsPtrInput interface {
 	pulumi.Input
 
@@ -793,7 +793,7 @@ type AlertChannelWebhook struct {
 // AlertChannelWebhookInput is an input type that accepts AlertChannelWebhookArgs and AlertChannelWebhookOutput values.
 // You can construct a concrete instance of `AlertChannelWebhookInput` via:
 //
-//          AlertChannelWebhookArgs{...}
+//	AlertChannelWebhookArgs{...}
 type AlertChannelWebhookInput interface {
 	pulumi.Input
 
@@ -834,11 +834,11 @@ func (i AlertChannelWebhookArgs) ToAlertChannelWebhookPtrOutputWithContext(ctx c
 // AlertChannelWebhookPtrInput is an input type that accepts AlertChannelWebhookArgs, AlertChannelWebhookPtr and AlertChannelWebhookPtrOutput values.
 // You can construct a concrete instance of `AlertChannelWebhookPtrInput` via:
 //
-//          AlertChannelWebhookArgs{...}
+//	        AlertChannelWebhookArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AlertChannelWebhookPtrInput interface {
 	pulumi.Input
 
@@ -1011,7 +1011,7 @@ type CheckAlertChannelSubscription struct {
 // CheckAlertChannelSubscriptionInput is an input type that accepts CheckAlertChannelSubscriptionArgs and CheckAlertChannelSubscriptionOutput values.
 // You can construct a concrete instance of `CheckAlertChannelSubscriptionInput` via:
 //
-//          CheckAlertChannelSubscriptionArgs{...}
+//	CheckAlertChannelSubscriptionArgs{...}
 type CheckAlertChannelSubscriptionInput interface {
 	pulumi.Input
 
@@ -1039,7 +1039,7 @@ func (i CheckAlertChannelSubscriptionArgs) ToCheckAlertChannelSubscriptionOutput
 // CheckAlertChannelSubscriptionArrayInput is an input type that accepts CheckAlertChannelSubscriptionArray and CheckAlertChannelSubscriptionArrayOutput values.
 // You can construct a concrete instance of `CheckAlertChannelSubscriptionArrayInput` via:
 //
-//          CheckAlertChannelSubscriptionArray{ CheckAlertChannelSubscriptionArgs{...} }
+//	CheckAlertChannelSubscriptionArray{ CheckAlertChannelSubscriptionArgs{...} }
 type CheckAlertChannelSubscriptionArrayInput interface {
 	pulumi.Input
 
@@ -1115,7 +1115,7 @@ type CheckAlertSettings struct {
 // CheckAlertSettingsInput is an input type that accepts CheckAlertSettingsArgs and CheckAlertSettingsOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsInput` via:
 //
-//          CheckAlertSettingsArgs{...}
+//	CheckAlertSettingsArgs{...}
 type CheckAlertSettingsInput interface {
 	pulumi.Input
 
@@ -1155,11 +1155,11 @@ func (i CheckAlertSettingsArgs) ToCheckAlertSettingsPtrOutputWithContext(ctx con
 // CheckAlertSettingsPtrInput is an input type that accepts CheckAlertSettingsArgs, CheckAlertSettingsPtr and CheckAlertSettingsPtrOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsPtrInput` via:
 //
-//          CheckAlertSettingsArgs{...}
+//	        CheckAlertSettingsArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckAlertSettingsPtrInput interface {
 	pulumi.Input
 
@@ -1308,7 +1308,7 @@ type CheckAlertSettingsReminder struct {
 // CheckAlertSettingsReminderInput is an input type that accepts CheckAlertSettingsReminderArgs and CheckAlertSettingsReminderOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsReminderInput` via:
 //
-//          CheckAlertSettingsReminderArgs{...}
+//	CheckAlertSettingsReminderArgs{...}
 type CheckAlertSettingsReminderInput interface {
 	pulumi.Input
 
@@ -1336,7 +1336,7 @@ func (i CheckAlertSettingsReminderArgs) ToCheckAlertSettingsReminderOutputWithCo
 // CheckAlertSettingsReminderArrayInput is an input type that accepts CheckAlertSettingsReminderArray and CheckAlertSettingsReminderArrayOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsReminderArrayInput` via:
 //
-//          CheckAlertSettingsReminderArray{ CheckAlertSettingsReminderArgs{...} }
+//	CheckAlertSettingsReminderArray{ CheckAlertSettingsReminderArgs{...} }
 type CheckAlertSettingsReminderArrayInput interface {
 	pulumi.Input
 
@@ -1407,7 +1407,7 @@ type CheckAlertSettingsRunBasedEscalation struct {
 // CheckAlertSettingsRunBasedEscalationInput is an input type that accepts CheckAlertSettingsRunBasedEscalationArgs and CheckAlertSettingsRunBasedEscalationOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsRunBasedEscalationInput` via:
 //
-//          CheckAlertSettingsRunBasedEscalationArgs{...}
+//	CheckAlertSettingsRunBasedEscalationArgs{...}
 type CheckAlertSettingsRunBasedEscalationInput interface {
 	pulumi.Input
 
@@ -1434,7 +1434,7 @@ func (i CheckAlertSettingsRunBasedEscalationArgs) ToCheckAlertSettingsRunBasedEs
 // CheckAlertSettingsRunBasedEscalationArrayInput is an input type that accepts CheckAlertSettingsRunBasedEscalationArray and CheckAlertSettingsRunBasedEscalationArrayOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsRunBasedEscalationArrayInput` via:
 //
-//          CheckAlertSettingsRunBasedEscalationArray{ CheckAlertSettingsRunBasedEscalationArgs{...} }
+//	CheckAlertSettingsRunBasedEscalationArray{ CheckAlertSettingsRunBasedEscalationArgs{...} }
 type CheckAlertSettingsRunBasedEscalationArrayInput interface {
 	pulumi.Input
 
@@ -1502,7 +1502,7 @@ type CheckAlertSettingsSslCertificate struct {
 // CheckAlertSettingsSslCertificateInput is an input type that accepts CheckAlertSettingsSslCertificateArgs and CheckAlertSettingsSslCertificateOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsSslCertificateInput` via:
 //
-//          CheckAlertSettingsSslCertificateArgs{...}
+//	CheckAlertSettingsSslCertificateArgs{...}
 type CheckAlertSettingsSslCertificateInput interface {
 	pulumi.Input
 
@@ -1530,7 +1530,7 @@ func (i CheckAlertSettingsSslCertificateArgs) ToCheckAlertSettingsSslCertificate
 // CheckAlertSettingsSslCertificateArrayInput is an input type that accepts CheckAlertSettingsSslCertificateArray and CheckAlertSettingsSslCertificateArrayOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsSslCertificateArrayInput` via:
 //
-//          CheckAlertSettingsSslCertificateArray{ CheckAlertSettingsSslCertificateArgs{...} }
+//	CheckAlertSettingsSslCertificateArray{ CheckAlertSettingsSslCertificateArgs{...} }
 type CheckAlertSettingsSslCertificateArrayInput interface {
 	pulumi.Input
 
@@ -1601,7 +1601,7 @@ type CheckAlertSettingsTimeBasedEscalation struct {
 // CheckAlertSettingsTimeBasedEscalationInput is an input type that accepts CheckAlertSettingsTimeBasedEscalationArgs and CheckAlertSettingsTimeBasedEscalationOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsTimeBasedEscalationInput` via:
 //
-//          CheckAlertSettingsTimeBasedEscalationArgs{...}
+//	CheckAlertSettingsTimeBasedEscalationArgs{...}
 type CheckAlertSettingsTimeBasedEscalationInput interface {
 	pulumi.Input
 
@@ -1628,7 +1628,7 @@ func (i CheckAlertSettingsTimeBasedEscalationArgs) ToCheckAlertSettingsTimeBased
 // CheckAlertSettingsTimeBasedEscalationArrayInput is an input type that accepts CheckAlertSettingsTimeBasedEscalationArray and CheckAlertSettingsTimeBasedEscalationArrayOutput values.
 // You can construct a concrete instance of `CheckAlertSettingsTimeBasedEscalationArrayInput` via:
 //
-//          CheckAlertSettingsTimeBasedEscalationArray{ CheckAlertSettingsTimeBasedEscalationArgs{...} }
+//	CheckAlertSettingsTimeBasedEscalationArray{ CheckAlertSettingsTimeBasedEscalationArgs{...} }
 type CheckAlertSettingsTimeBasedEscalationArrayInput interface {
 	pulumi.Input
 
@@ -1697,7 +1697,7 @@ type CheckEnvironmentVariable struct {
 // CheckEnvironmentVariableInput is an input type that accepts CheckEnvironmentVariableArgs and CheckEnvironmentVariableOutput values.
 // You can construct a concrete instance of `CheckEnvironmentVariableInput` via:
 //
-//          CheckEnvironmentVariableArgs{...}
+//	CheckEnvironmentVariableArgs{...}
 type CheckEnvironmentVariableInput interface {
 	pulumi.Input
 
@@ -1757,7 +1757,7 @@ type CheckGroupAlertChannelSubscription struct {
 // CheckGroupAlertChannelSubscriptionInput is an input type that accepts CheckGroupAlertChannelSubscriptionArgs and CheckGroupAlertChannelSubscriptionOutput values.
 // You can construct a concrete instance of `CheckGroupAlertChannelSubscriptionInput` via:
 //
-//          CheckGroupAlertChannelSubscriptionArgs{...}
+//	CheckGroupAlertChannelSubscriptionArgs{...}
 type CheckGroupAlertChannelSubscriptionInput interface {
 	pulumi.Input
 
@@ -1785,7 +1785,7 @@ func (i CheckGroupAlertChannelSubscriptionArgs) ToCheckGroupAlertChannelSubscrip
 // CheckGroupAlertChannelSubscriptionArrayInput is an input type that accepts CheckGroupAlertChannelSubscriptionArray and CheckGroupAlertChannelSubscriptionArrayOutput values.
 // You can construct a concrete instance of `CheckGroupAlertChannelSubscriptionArrayInput` via:
 //
-//          CheckGroupAlertChannelSubscriptionArray{ CheckGroupAlertChannelSubscriptionArgs{...} }
+//	CheckGroupAlertChannelSubscriptionArray{ CheckGroupAlertChannelSubscriptionArgs{...} }
 type CheckGroupAlertChannelSubscriptionArrayInput interface {
 	pulumi.Input
 
@@ -1861,7 +1861,7 @@ type CheckGroupAlertSettings struct {
 // CheckGroupAlertSettingsInput is an input type that accepts CheckGroupAlertSettingsArgs and CheckGroupAlertSettingsOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsInput` via:
 //
-//          CheckGroupAlertSettingsArgs{...}
+//	CheckGroupAlertSettingsArgs{...}
 type CheckGroupAlertSettingsInput interface {
 	pulumi.Input
 
@@ -1901,11 +1901,11 @@ func (i CheckGroupAlertSettingsArgs) ToCheckGroupAlertSettingsPtrOutputWithConte
 // CheckGroupAlertSettingsPtrInput is an input type that accepts CheckGroupAlertSettingsArgs, CheckGroupAlertSettingsPtr and CheckGroupAlertSettingsPtrOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsPtrInput` via:
 //
-//          CheckGroupAlertSettingsArgs{...}
+//	        CheckGroupAlertSettingsArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckGroupAlertSettingsPtrInput interface {
 	pulumi.Input
 
@@ -2058,7 +2058,7 @@ type CheckGroupAlertSettingsReminder struct {
 // CheckGroupAlertSettingsReminderInput is an input type that accepts CheckGroupAlertSettingsReminderArgs and CheckGroupAlertSettingsReminderOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsReminderInput` via:
 //
-//          CheckGroupAlertSettingsReminderArgs{...}
+//	CheckGroupAlertSettingsReminderArgs{...}
 type CheckGroupAlertSettingsReminderInput interface {
 	pulumi.Input
 
@@ -2086,7 +2086,7 @@ func (i CheckGroupAlertSettingsReminderArgs) ToCheckGroupAlertSettingsReminderOu
 // CheckGroupAlertSettingsReminderArrayInput is an input type that accepts CheckGroupAlertSettingsReminderArray and CheckGroupAlertSettingsReminderArrayOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsReminderArrayInput` via:
 //
-//          CheckGroupAlertSettingsReminderArray{ CheckGroupAlertSettingsReminderArgs{...} }
+//	CheckGroupAlertSettingsReminderArray{ CheckGroupAlertSettingsReminderArgs{...} }
 type CheckGroupAlertSettingsReminderArrayInput interface {
 	pulumi.Input
 
@@ -2157,7 +2157,7 @@ type CheckGroupAlertSettingsRunBasedEscalation struct {
 // CheckGroupAlertSettingsRunBasedEscalationInput is an input type that accepts CheckGroupAlertSettingsRunBasedEscalationArgs and CheckGroupAlertSettingsRunBasedEscalationOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsRunBasedEscalationInput` via:
 //
-//          CheckGroupAlertSettingsRunBasedEscalationArgs{...}
+//	CheckGroupAlertSettingsRunBasedEscalationArgs{...}
 type CheckGroupAlertSettingsRunBasedEscalationInput interface {
 	pulumi.Input
 
@@ -2184,7 +2184,7 @@ func (i CheckGroupAlertSettingsRunBasedEscalationArgs) ToCheckGroupAlertSettings
 // CheckGroupAlertSettingsRunBasedEscalationArrayInput is an input type that accepts CheckGroupAlertSettingsRunBasedEscalationArray and CheckGroupAlertSettingsRunBasedEscalationArrayOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsRunBasedEscalationArrayInput` via:
 //
-//          CheckGroupAlertSettingsRunBasedEscalationArray{ CheckGroupAlertSettingsRunBasedEscalationArgs{...} }
+//	CheckGroupAlertSettingsRunBasedEscalationArray{ CheckGroupAlertSettingsRunBasedEscalationArgs{...} }
 type CheckGroupAlertSettingsRunBasedEscalationArrayInput interface {
 	pulumi.Input
 
@@ -2252,7 +2252,7 @@ type CheckGroupAlertSettingsSslCertificate struct {
 // CheckGroupAlertSettingsSslCertificateInput is an input type that accepts CheckGroupAlertSettingsSslCertificateArgs and CheckGroupAlertSettingsSslCertificateOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsSslCertificateInput` via:
 //
-//          CheckGroupAlertSettingsSslCertificateArgs{...}
+//	CheckGroupAlertSettingsSslCertificateArgs{...}
 type CheckGroupAlertSettingsSslCertificateInput interface {
 	pulumi.Input
 
@@ -2280,7 +2280,7 @@ func (i CheckGroupAlertSettingsSslCertificateArgs) ToCheckGroupAlertSettingsSslC
 // CheckGroupAlertSettingsSslCertificateArrayInput is an input type that accepts CheckGroupAlertSettingsSslCertificateArray and CheckGroupAlertSettingsSslCertificateArrayOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsSslCertificateArrayInput` via:
 //
-//          CheckGroupAlertSettingsSslCertificateArray{ CheckGroupAlertSettingsSslCertificateArgs{...} }
+//	CheckGroupAlertSettingsSslCertificateArray{ CheckGroupAlertSettingsSslCertificateArgs{...} }
 type CheckGroupAlertSettingsSslCertificateArrayInput interface {
 	pulumi.Input
 
@@ -2351,7 +2351,7 @@ type CheckGroupAlertSettingsTimeBasedEscalation struct {
 // CheckGroupAlertSettingsTimeBasedEscalationInput is an input type that accepts CheckGroupAlertSettingsTimeBasedEscalationArgs and CheckGroupAlertSettingsTimeBasedEscalationOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsTimeBasedEscalationInput` via:
 //
-//          CheckGroupAlertSettingsTimeBasedEscalationArgs{...}
+//	CheckGroupAlertSettingsTimeBasedEscalationArgs{...}
 type CheckGroupAlertSettingsTimeBasedEscalationInput interface {
 	pulumi.Input
 
@@ -2378,7 +2378,7 @@ func (i CheckGroupAlertSettingsTimeBasedEscalationArgs) ToCheckGroupAlertSetting
 // CheckGroupAlertSettingsTimeBasedEscalationArrayInput is an input type that accepts CheckGroupAlertSettingsTimeBasedEscalationArray and CheckGroupAlertSettingsTimeBasedEscalationArrayOutput values.
 // You can construct a concrete instance of `CheckGroupAlertSettingsTimeBasedEscalationArrayInput` via:
 //
-//          CheckGroupAlertSettingsTimeBasedEscalationArray{ CheckGroupAlertSettingsTimeBasedEscalationArgs{...} }
+//	CheckGroupAlertSettingsTimeBasedEscalationArray{ CheckGroupAlertSettingsTimeBasedEscalationArgs{...} }
 type CheckGroupAlertSettingsTimeBasedEscalationArrayInput interface {
 	pulumi.Input
 
@@ -2462,7 +2462,7 @@ func (val *CheckGroupApiCheckDefaults) Defaults() *CheckGroupApiCheckDefaults {
 // CheckGroupApiCheckDefaultsInput is an input type that accepts CheckGroupApiCheckDefaultsArgs and CheckGroupApiCheckDefaultsOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsInput` via:
 //
-//          CheckGroupApiCheckDefaultsArgs{...}
+//	CheckGroupApiCheckDefaultsArgs{...}
 type CheckGroupApiCheckDefaultsInput interface {
 	pulumi.Input
 
@@ -2501,11 +2501,11 @@ func (i CheckGroupApiCheckDefaultsArgs) ToCheckGroupApiCheckDefaultsPtrOutputWit
 // CheckGroupApiCheckDefaultsPtrInput is an input type that accepts CheckGroupApiCheckDefaultsArgs, CheckGroupApiCheckDefaultsPtr and CheckGroupApiCheckDefaultsPtrOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsPtrInput` via:
 //
-//          CheckGroupApiCheckDefaultsArgs{...}
+//	        CheckGroupApiCheckDefaultsArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckGroupApiCheckDefaultsPtrInput interface {
 	pulumi.Input
 
@@ -2654,7 +2654,7 @@ type CheckGroupApiCheckDefaultsAssertion struct {
 // CheckGroupApiCheckDefaultsAssertionInput is an input type that accepts CheckGroupApiCheckDefaultsAssertionArgs and CheckGroupApiCheckDefaultsAssertionOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsAssertionInput` via:
 //
-//          CheckGroupApiCheckDefaultsAssertionArgs{...}
+//	CheckGroupApiCheckDefaultsAssertionArgs{...}
 type CheckGroupApiCheckDefaultsAssertionInput interface {
 	pulumi.Input
 
@@ -2684,7 +2684,7 @@ func (i CheckGroupApiCheckDefaultsAssertionArgs) ToCheckGroupApiCheckDefaultsAss
 // CheckGroupApiCheckDefaultsAssertionArrayInput is an input type that accepts CheckGroupApiCheckDefaultsAssertionArray and CheckGroupApiCheckDefaultsAssertionArrayOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsAssertionArrayInput` via:
 //
-//          CheckGroupApiCheckDefaultsAssertionArray{ CheckGroupApiCheckDefaultsAssertionArgs{...} }
+//	CheckGroupApiCheckDefaultsAssertionArray{ CheckGroupApiCheckDefaultsAssertionArgs{...} }
 type CheckGroupApiCheckDefaultsAssertionArrayInput interface {
 	pulumi.Input
 
@@ -2764,7 +2764,7 @@ type CheckGroupApiCheckDefaultsBasicAuth struct {
 // CheckGroupApiCheckDefaultsBasicAuthInput is an input type that accepts CheckGroupApiCheckDefaultsBasicAuthArgs and CheckGroupApiCheckDefaultsBasicAuthOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsBasicAuthInput` via:
 //
-//          CheckGroupApiCheckDefaultsBasicAuthArgs{...}
+//	CheckGroupApiCheckDefaultsBasicAuthArgs{...}
 type CheckGroupApiCheckDefaultsBasicAuthInput interface {
 	pulumi.Input
 
@@ -2800,11 +2800,11 @@ func (i CheckGroupApiCheckDefaultsBasicAuthArgs) ToCheckGroupApiCheckDefaultsBas
 // CheckGroupApiCheckDefaultsBasicAuthPtrInput is an input type that accepts CheckGroupApiCheckDefaultsBasicAuthArgs, CheckGroupApiCheckDefaultsBasicAuthPtr and CheckGroupApiCheckDefaultsBasicAuthPtrOutput values.
 // You can construct a concrete instance of `CheckGroupApiCheckDefaultsBasicAuthPtrInput` via:
 //
-//          CheckGroupApiCheckDefaultsBasicAuthArgs{...}
+//	        CheckGroupApiCheckDefaultsBasicAuthArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckGroupApiCheckDefaultsBasicAuthPtrInput interface {
 	pulumi.Input
 
@@ -2913,7 +2913,7 @@ type CheckGroupEnvironmentVariable struct {
 // CheckGroupEnvironmentVariableInput is an input type that accepts CheckGroupEnvironmentVariableArgs and CheckGroupEnvironmentVariableOutput values.
 // You can construct a concrete instance of `CheckGroupEnvironmentVariableInput` via:
 //
-//          CheckGroupEnvironmentVariableArgs{...}
+//	CheckGroupEnvironmentVariableArgs{...}
 type CheckGroupEnvironmentVariableInput interface {
 	pulumi.Input
 
@@ -2981,7 +2981,7 @@ type CheckRequest struct {
 // CheckRequestInput is an input type that accepts CheckRequestArgs and CheckRequestOutput values.
 // You can construct a concrete instance of `CheckRequestInput` via:
 //
-//          CheckRequestArgs{...}
+//	CheckRequestArgs{...}
 type CheckRequestInput interface {
 	pulumi.Input
 
@@ -3025,11 +3025,11 @@ func (i CheckRequestArgs) ToCheckRequestPtrOutputWithContext(ctx context.Context
 // CheckRequestPtrInput is an input type that accepts CheckRequestArgs, CheckRequestPtr and CheckRequestPtrOutput values.
 // You can construct a concrete instance of `CheckRequestPtrInput` via:
 //
-//          CheckRequestArgs{...}
+//	        CheckRequestArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckRequestPtrInput interface {
 	pulumi.Input
 
@@ -3243,7 +3243,7 @@ type CheckRequestAssertion struct {
 // CheckRequestAssertionInput is an input type that accepts CheckRequestAssertionArgs and CheckRequestAssertionOutput values.
 // You can construct a concrete instance of `CheckRequestAssertionInput` via:
 //
-//          CheckRequestAssertionArgs{...}
+//	CheckRequestAssertionArgs{...}
 type CheckRequestAssertionInput interface {
 	pulumi.Input
 
@@ -3273,7 +3273,7 @@ func (i CheckRequestAssertionArgs) ToCheckRequestAssertionOutputWithContext(ctx 
 // CheckRequestAssertionArrayInput is an input type that accepts CheckRequestAssertionArray and CheckRequestAssertionArrayOutput values.
 // You can construct a concrete instance of `CheckRequestAssertionArrayInput` via:
 //
-//          CheckRequestAssertionArray{ CheckRequestAssertionArgs{...} }
+//	CheckRequestAssertionArray{ CheckRequestAssertionArgs{...} }
 type CheckRequestAssertionArrayInput interface {
 	pulumi.Input
 
@@ -3353,7 +3353,7 @@ type CheckRequestBasicAuth struct {
 // CheckRequestBasicAuthInput is an input type that accepts CheckRequestBasicAuthArgs and CheckRequestBasicAuthOutput values.
 // You can construct a concrete instance of `CheckRequestBasicAuthInput` via:
 //
-//          CheckRequestBasicAuthArgs{...}
+//	CheckRequestBasicAuthArgs{...}
 type CheckRequestBasicAuthInput interface {
 	pulumi.Input
 
@@ -3389,11 +3389,11 @@ func (i CheckRequestBasicAuthArgs) ToCheckRequestBasicAuthPtrOutputWithContext(c
 // CheckRequestBasicAuthPtrInput is an input type that accepts CheckRequestBasicAuthArgs, CheckRequestBasicAuthPtr and CheckRequestBasicAuthPtrOutput values.
 // You can construct a concrete instance of `CheckRequestBasicAuthPtrInput` via:
 //
-//          CheckRequestBasicAuthArgs{...}
+//	        CheckRequestBasicAuthArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type CheckRequestBasicAuthPtrInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/pulumiUtilities.go
+++ b/sdk/go/checkly/pulumiUtilities.go
@@ -86,14 +86,14 @@ func isZero(v interface{}) bool {
 
 // pkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func pkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
-	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}")}
+	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("github://api.github.com/checkly")}
 
 	return append(defaults, opts...)
 }
 
 // pkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func pkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
-	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}")}
+	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("github://api.github.com/checkly")}
 
 	return append(defaults, opts...)
 }

--- a/sdk/go/checkly/snippet.go
+++ b/sdk/go/checkly/snippet.go
@@ -111,7 +111,7 @@ func (i *Snippet) ToSnippetOutputWithContext(ctx context.Context) SnippetOutput 
 // SnippetArrayInput is an input type that accepts SnippetArray and SnippetArrayOutput values.
 // You can construct a concrete instance of `SnippetArrayInput` via:
 //
-//          SnippetArray{ SnippetArgs{...} }
+//	SnippetArray{ SnippetArgs{...} }
 type SnippetArrayInput interface {
 	pulumi.Input
 
@@ -136,7 +136,7 @@ func (i SnippetArray) ToSnippetArrayOutputWithContext(ctx context.Context) Snipp
 // SnippetMapInput is an input type that accepts SnippetMap and SnippetMapOutput values.
 // You can construct a concrete instance of `SnippetMapInput` via:
 //
-//          SnippetMap{ "key": SnippetArgs{...} }
+//	SnippetMap{ "key": SnippetArgs{...} }
 type SnippetMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/triggerCheck.go
+++ b/sdk/go/checkly/triggerCheck.go
@@ -17,22 +17,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		testTriggerCheck, err := checkly.NewTriggerCheck(ctx, "testTriggerCheck", &checkly.TriggerCheckArgs{
-// 			CheckId: pulumi.String("c1ff95c5-d7f6-4a90-9ce2-1e605f117592"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		ctx.Export("testTriggerCheckUrl", testTriggerCheck.Url)
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			testTriggerCheck, err := checkly.NewTriggerCheck(ctx, "testTriggerCheck", &checkly.TriggerCheckArgs{
+//				CheckId: pulumi.String("c1ff95c5-d7f6-4a90-9ce2-1e605f117592"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			ctx.Export("testTriggerCheckUrl", testTriggerCheck.Url)
+//			return nil
+//		})
+//	}
+//
 // ```
 type TriggerCheck struct {
 	pulumi.CustomResourceState
@@ -144,7 +147,7 @@ func (i *TriggerCheck) ToTriggerCheckOutputWithContext(ctx context.Context) Trig
 // TriggerCheckArrayInput is an input type that accepts TriggerCheckArray and TriggerCheckArrayOutput values.
 // You can construct a concrete instance of `TriggerCheckArrayInput` via:
 //
-//          TriggerCheckArray{ TriggerCheckArgs{...} }
+//	TriggerCheckArray{ TriggerCheckArgs{...} }
 type TriggerCheckArrayInput interface {
 	pulumi.Input
 
@@ -169,7 +172,7 @@ func (i TriggerCheckArray) ToTriggerCheckArrayOutputWithContext(ctx context.Cont
 // TriggerCheckMapInput is an input type that accepts TriggerCheckMap and TriggerCheckMapOutput values.
 // You can construct a concrete instance of `TriggerCheckMapInput` via:
 //
-//          TriggerCheckMap{ "key": TriggerCheckArgs{...} }
+//	TriggerCheckMap{ "key": TriggerCheckArgs{...} }
 type TriggerCheckMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/checkly/triggerCheckGroup.go
+++ b/sdk/go/checkly/triggerCheckGroup.go
@@ -17,22 +17,25 @@ import (
 // package main
 //
 // import (
-// 	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/checkly/pulumi-checkly/sdk/go/checkly"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		testTriggerGroup, err := checkly.NewTriggerCheckGroup(ctx, "testTriggerGroup", &checkly.TriggerCheckGroupArgs{
-// 			GroupId: pulumi.Int(215),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		ctx.Export("testTriggerGroupUrl", testTriggerGroup.Url)
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			testTriggerGroup, err := checkly.NewTriggerCheckGroup(ctx, "testTriggerGroup", &checkly.TriggerCheckGroupArgs{
+//				GroupId: pulumi.Int(215),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			ctx.Export("testTriggerGroupUrl", testTriggerGroup.Url)
+//			return nil
+//		})
+//	}
+//
 // ```
 type TriggerCheckGroup struct {
 	pulumi.CustomResourceState
@@ -144,7 +147,7 @@ func (i *TriggerCheckGroup) ToTriggerCheckGroupOutputWithContext(ctx context.Con
 // TriggerCheckGroupArrayInput is an input type that accepts TriggerCheckGroupArray and TriggerCheckGroupArrayOutput values.
 // You can construct a concrete instance of `TriggerCheckGroupArrayInput` via:
 //
-//          TriggerCheckGroupArray{ TriggerCheckGroupArgs{...} }
+//	TriggerCheckGroupArray{ TriggerCheckGroupArgs{...} }
 type TriggerCheckGroupArrayInput interface {
 	pulumi.Input
 
@@ -169,7 +172,7 @@ func (i TriggerCheckGroupArray) ToTriggerCheckGroupArrayOutputWithContext(ctx co
 // TriggerCheckGroupMapInput is an input type that accepts TriggerCheckGroupMap and TriggerCheckGroupMapOutput values.
 // You can construct a concrete instance of `TriggerCheckGroupMapInput` via:
 //
-//          TriggerCheckGroupMap{ "key": TriggerCheckGroupArgs{...} }
+//	TriggerCheckGroupMap{ "key": TriggerCheckGroupArgs{...} }
 type TriggerCheckGroupMapInput interface {
 	pulumi.Input
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -24,6 +24,6 @@
     },
     "pulumi": {
         "resource": true,
-        "pluginDownloadURL": "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"
+        "pluginDownloadURL": "github://api.github.com/checkly"
     }
 }

--- a/sdk/nodejs/scripts/install-pulumi-plugin.js
+++ b/sdk/nodejs/scripts/install-pulumi-plugin.js
@@ -7,7 +7,7 @@ if (args.indexOf("${VERSION}") !== -1) {
 	process.exit(0);
 }
 
-var res = childProcess.spawnSync("pulumi", ["plugin", "install", "--server", "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"].concat(args), {
+var res = childProcess.spawnSync("pulumi", ["plugin", "install", "--server", "github://api.github.com/checkly"].concat(args), {
     stdio: ["ignore", "inherit", "inherit"]
 });
 

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -50,5 +50,5 @@ export function getVersion(): string {
 
 /** @internal */
 export function resourceOptsDefaults(): any {
-    return { version: getVersion(), pluginDownloadURL: "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}" };
+    return { version: getVersion(), pluginDownloadURL: "github://api.github.com/checkly" };
 }

--- a/sdk/python/pulumi_checkly/_utilities.py
+++ b/sdk/python/pulumi_checkly/_utilities.py
@@ -236,4 +236,4 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
     return (lambda _: lifted_func)
 
 def get_plugin_download_url():
-	return "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"
+	return "github://api.github.com/checkly"

--- a/sdk/python/pulumi_checkly/pulumi-plugin.json
+++ b/sdk/python/pulumi_checkly/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "checkly",
-  "server": "https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}"
+  "server": "github://api.github.com/checkly"
 }

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -15,7 +15,7 @@ class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'checkly', PLUGIN_VERSION, '--server', 'https://github.com/checkly/pulumi-checkly/releases/download/v${VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'checkly', PLUGIN_VERSION, '--server', 'github://api.github.com/checkly'])
         except OSError as error:
             if error.errno == errno.ENOENT:
                 print(f"""


### PR DESCRIPTION
## Affected Components
* [ ] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [x] Other

## Pre-Requisites
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

At Pulumi, we added [support for the Github Releases API](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/#support-for-github-releases) (rather than a regular https://github.com/... URL) to download the the plugin binaries. This is a more stable way of finding the right plugin binary.

I updated the `pluginDownloadUrl` and configured the `github:` protocol handler. I rebuilt the provider & SDKs for this new URL to be integrated into it.