### PR TITLE
feat: update TF provider to v1.11.1 to fix broken get_static_ips [sc-24640]

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.5
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250124205414-92ccb3765401
 
 require (
-	github.com/checkly/terraform-provider-checkly v1.11.0
+	github.com/checkly/terraform-provider-checkly v1.11.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.102.0
 	github.com/pulumi/pulumi/pkg/v3 v3.147.0
 	github.com/pulumi/pulumi/sdk/v3 v3.147.0
@@ -40,7 +40,7 @@ require (
 	github.com/charmbracelet/bubbles v0.16.1 // indirect
 	github.com/charmbracelet/bubbletea v0.25.0 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
-	github.com/checkly/checkly-go-sdk v1.11.0 // indirect
+	github.com/checkly/checkly-go-sdk v1.11.1 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1472,10 +1472,10 @@ github.com/charmbracelet/bubbletea v0.25.0 h1:bAfwk7jRz7FKFl9RzlIULPkStffg5k6pNt
 github.com/charmbracelet/bubbletea v0.25.0/go.mod h1:EN3QDR1T5ZdWmdfDzYcqOCAps45+QIJbLOBxmVNWNNg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
-github.com/checkly/checkly-go-sdk v1.11.0 h1:rMlELoLEZNZzxqKLPCeptjBMdDeBcM4eV/NlGK+psik=
-github.com/checkly/checkly-go-sdk v1.11.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/terraform-provider-checkly v1.11.0 h1:ORHxUiGeMTJ3TDNNrIyRTDKbrTEpP2KkKAs1YXVY0II=
-github.com/checkly/terraform-provider-checkly v1.11.0/go.mod h1:gtJdJY2JoSQdfEKe5iXRYAWQ1J2xyUH6CxNExrd4OCo=
+github.com/checkly/checkly-go-sdk v1.11.1 h1:U4beSPUDzJ48AJ43/n/y//zJG7JtrBxLmmOgUIc5jOc=
+github.com/checkly/checkly-go-sdk v1.11.1/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/terraform-provider-checkly v1.11.1 h1:yPVap0t4Klc0t30He61RlqsOOZz1eJPYAzA7/I86fYk=
+github.com/checkly/terraform-provider-checkly v1.11.1/go.mod h1:3UwHAI1fBXgkW1cGn2so2eN9SJuqJyAAsc6QN0Vg2+k=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=


### PR DESCRIPTION
This PR updates the TF provider to v1.11.1 which fixes get_static_ips. It was broken by an incompatible API change.

Since this is a simple internal fix, calling `make provider build_sdks` did not change any files.

## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
