### PR TITLE
fix: make it possible to unassign a check/monitor from a group

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/checkly/terraform-provider-checkly v1.14.0
+	github.com/checkly/terraform-provider-checkly v1.15.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.114.0
 	github.com/pulumi/pulumi/pkg/v3 v3.190.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
@@ -46,7 +46,7 @@ require (
 	github.com/charmbracelet/bubbles v0.16.1 // indirect
 	github.com/charmbracelet/bubbletea v0.25.0 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
-	github.com/checkly/checkly-go-sdk v1.15.0 // indirect
+	github.com/checkly/checkly-go-sdk v1.16.0 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1502,10 +1502,10 @@ github.com/charmbracelet/bubbletea v0.25.0 h1:bAfwk7jRz7FKFl9RzlIULPkStffg5k6pNt
 github.com/charmbracelet/bubbletea v0.25.0/go.mod h1:EN3QDR1T5ZdWmdfDzYcqOCAps45+QIJbLOBxmVNWNNg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
-github.com/checkly/checkly-go-sdk v1.15.0 h1:H8157N+/MrF8KebPgFAK/9fJxFSeseegUJAwDyHoMKo=
-github.com/checkly/checkly-go-sdk v1.15.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
-github.com/checkly/terraform-provider-checkly v1.14.0 h1:k7rFmYFEJWohKtrD4FCf9cmu+8Wpbm2hIl8MwECkysc=
-github.com/checkly/terraform-provider-checkly v1.14.0/go.mod h1:+f2Z/XNINgSpeYhG7xp0VxAGXg9+CnxCvV56yzHUZLo=
+github.com/checkly/checkly-go-sdk v1.16.0 h1:m8ixcmHlNxnls/sFlcAa48j3xrvEcBaDcHnYOL9gbZM=
+github.com/checkly/checkly-go-sdk v1.16.0/go.mod h1:Pd6tBOggAe41NnCU5KwqA8JvD6J20/IctszT2E0AvHo=
+github.com/checkly/terraform-provider-checkly v1.15.0 h1:wBK768jik36DdtRpOYVF/D4AIxtR8HnB/41gppacavc=
+github.com/checkly/terraform-provider-checkly v1.15.0/go.mod h1:gXT5BxpAIUzpVs7o730ZI+tVsY+rLnqaTayR78iUj6I=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=


### PR DESCRIPTION
Updates terraform-provider-checkly to [v1.15.0](https://github.com/checkly/terraform-provider-checkly/releases/tag/v1.15.0) which fixes the issue.

## Affected Components
* [x] Resources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
